### PR TITLE
replace dependency: faker -> @js-faker/faker

### DIFF
--- a/generator.js
+++ b/generator.js
@@ -1,4 +1,4 @@
-const faker = require('faker');
+const faker = require('@faker-js/faker').default;
 
 module.exports = () => {
     const data = {
@@ -9,7 +9,7 @@ module.exports = () => {
     }
 
     const amountOfProducts = 1000;
-    const amountOfRecommendedProduts = 10;
+    const amountOfRecommendedProducts = 10;
     const amountOfUsers = 100;
 
     /**
@@ -28,10 +28,10 @@ module.exports = () => {
             faker.image.cats(),
             faker.image.cats()
         ];
-        product.price = faker.random.float();
-        product.discount = faker.random.number(70);
+        product.price = faker.datatype.float();
+        product.discount = faker.datatype.number(70);
 
-        if (i <= amountOfRecommendedProduts) {
+        if (i <= amountOfRecommendedProducts) {
             data.recommendeds.push(product);
         }
         data.products.push(product);
@@ -63,11 +63,11 @@ module.exports = () => {
         user.role = i % 2 ? 'ADMIN' : 'CUSTOMER';
 
         // Random products that the user has ordered
-        for(let a = 1; a <= faker.random.number({min: 1, max: 5}); a++) {
+        for(let a = 1; a <= faker.datatype.number({min: 1, max: 5}); a++) {
             const orderedProducts = [];
-            for(let z = 1; z <= faker.random.number({min: 1, max: 5}); z++) {
-                const product = data.products[faker.random.number({min: 0, max: amountOfProducts - 1})];
-                orderedProducts.push({id: product.id, quantity: faker.random.number({min: 1, max: 10})});
+            for(let z = 1; z <= faker.datatype.number({min: 1, max: 5}); z++) {
+                const product = data.products[faker.datatype.number({min: 0, max: amountOfProducts - 1})];
+                orderedProducts.push({id: product.id, quantity: faker.datatype.number({min: 1, max: 10})});
             }
             user.orders.push({
                 id: a,
@@ -77,13 +77,13 @@ module.exports = () => {
 
         // Set random products into the user's cart
         const cart = [];
-        for(let y = 1; y <= faker.random.number(5); y++) {
-            const product = data.products[faker.random.number({min: 0, max: amountOfProducts - 1})]; 
-            cart.push({id: product.id, quantity: faker.random.number({min: 1, max: 10})});
+        for(let y = 1; y <= faker.datatype.number(5); y++) {
+            const product = data.products[faker.datatype.number({min: 0, max: amountOfProducts - 1})];
+            cart.push({id: product.id, quantity: faker.datatype.number({min: 1, max: 10})});
         }
         data.carts.push({id: user.id, products: cart});
 
-        
+
         data.users.push(user);
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,17 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "faker": "^5.4.0",
+        "@faker-js/faker": "^6.0.0",
         "json-server": "^0.16.3"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-6.0.0.tgz",
+      "integrity": "sha512-10zLCKhp3YEmBuko71ivcMoIZcCLXgQVck6aNswX+AWwaek/L8S3yz9i8m3tHigRkcF6F2vI+qtdtyySHK+bGA==",
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/@sindresorhus/is": {
@@ -676,12 +685,6 @@
       "dependencies": {
         "isarray": "0.0.1"
       }
-    },
-    "node_modules/faker": {
-      "version": "5.4.0",
-      "resolved": "https://registry.yarnpkg.com/faker/-/faker-5.4.0.tgz",
-      "integrity": "sha512-Y9n/Ky/xZx/Bj8DePvXspUYRtHl/rGQytoIT5LaxmNwSe3wWyOeOXb3lT6Dpipq240PVpeFaGKzScz/5fvff2g==",
-      "license": "MIT"
     },
     "node_modules/finalhandler": {
       "version": "1.1.2",
@@ -1957,6 +1960,11 @@
     }
   },
   "dependencies": {
+    "@faker-js/faker": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-6.0.0.tgz",
+      "integrity": "sha512-10zLCKhp3YEmBuko71ivcMoIZcCLXgQVck6aNswX+AWwaek/L8S3yz9i8m3tHigRkcF6F2vI+qtdtyySHK+bGA=="
+    },
     "@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -2422,11 +2430,6 @@
           }
         }
       }
-    },
-    "faker": {
-      "version": "5.4.0",
-      "resolved": "https://registry.yarnpkg.com/faker/-/faker-5.4.0.tgz",
-      "integrity": "sha512-Y9n/Ky/xZx/Bj8DePvXspUYRtHl/rGQytoIT5LaxmNwSe3wWyOeOXb3lT6Dpipq240PVpeFaGKzScz/5fvff2g=="
     },
     "finalhandler": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "json-server ./generator.js --port 8080 --delay 500"
   },
   "dependencies": {
-    "faker": "^5.4.0",
+    "@faker-js/faker": "^6.0.0",
     "json-server": "^0.16.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@faker-js/faker@^6.0.0":
+  "integrity" "sha512-10zLCKhp3YEmBuko71ivcMoIZcCLXgQVck6aNswX+AWwaek/L8S3yz9i8m3tHigRkcF6F2vI+qtdtyySHK+bGA=="
+  "resolved" "https://registry.npmjs.org/@faker-js/faker/-/faker-6.0.0.tgz"
+  "version" "6.0.0"
+
 "@sindresorhus/is@^0.14.0":
   "integrity" "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ=="
   "resolved" "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz"
@@ -397,11 +402,6 @@
     "type-is" "~1.6.18"
     "utils-merge" "1.0.1"
     "vary" "~1.1.2"
-
-"faker@^5.4.0":
-  "integrity" "sha512-Y9n/Ky/xZx/Bj8DePvXspUYRtHl/rGQytoIT5LaxmNwSe3wWyOeOXb3lT6Dpipq240PVpeFaGKzScz/5fvff2g=="
-  "resolved" "https://registry.yarnpkg.com/faker/-/faker-5.4.0.tgz"
-  "version" "5.4.0"
 
 "finalhandler@~1.1.2":
   "integrity" "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA=="


### PR DESCRIPTION
Replace `faker` with a newer alternative.

**Why?**

- image links are broken.
- the author of `faker` has deleted this library from github and npm.

**What?**

- replace the faker js library with [@js-faker/faker](https://fakerjs.dev/update.html).
- update deprecated `random` properties inside `generator.js`.
- fix typo in const name inside `generator.js`.

